### PR TITLE
feat: convertir bot en PWA para Cloudflare Pages con D1

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,121 @@
+const tz = Intl.DateTimeFormat().resolvedOptions().timeZone || "Europe/Madrid";
+document.getElementById("tz-text").textContent = tz;
+
+const registroTab = document.getElementById("tab-registro");
+const analiticasTab = document.getElementById("tab-analiticas");
+const btnRegistro = document.getElementById("tab-btn-registro");
+const btnAnaliticas = document.getElementById("tab-btn-analiticas");
+
+btnRegistro.addEventListener("click", () => setTab("registro"));
+btnAnaliticas.addEventListener("click", () => setTab("analiticas"));
+
+function setTab(tab) {
+  const isRegistro = tab === "registro";
+  registroTab.classList.toggle("active", isRegistro);
+  analiticasTab.classList.toggle("active", !isRegistro);
+  btnRegistro.classList.toggle("active", isRegistro);
+  btnAnaliticas.classList.toggle("active", !isRegistro);
+}
+
+const form = document.getElementById("registro-form");
+const formMsg = document.getElementById("form-msg");
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const payload = {
+    user_id: v("userId"),
+    estado: v("estado"),
+    hora_intento: dt("horaIntento"),
+    hora_sueno_efectivo: dt("horaDormido"),
+    hora_despertar: dt("horaDespertar"),
+    metodo: v("metodo") || null,
+  };
+
+  const res = await fetch("/api/registros", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    formMsg.textContent = `❌ ${data.error || "Error al guardar"}`;
+    formMsg.style.color = "#b91c1c";
+    return;
+  }
+
+  formMsg.textContent = "✅ Registro guardado";
+  formMsg.style.color = "#166534";
+  await Promise.all([loadRegistros(), loadAnaliticas()]);
+});
+
+document.getElementById("reload-registros").addEventListener("click", loadRegistros);
+document.getElementById("reload-analiticas").addEventListener("click", loadAnaliticas);
+
+async function loadRegistros() {
+  const userId = v("userId");
+  if (!userId) return;
+
+  const res = await fetch(`/api/registros?user_id=${encodeURIComponent(userId)}`);
+  const data = await res.json();
+  const lista = document.getElementById("registros-lista");
+
+  if (!res.ok) {
+    lista.innerHTML = `<p>❌ ${data.error || "Error cargando registros"}</p>`;
+    return;
+  }
+
+  if (!data.data.length) {
+    lista.innerHTML = "<p>Sin registros todavía.</p>";
+    return;
+  }
+
+  lista.innerHTML = data.data
+    .map((r) => `
+      <div class="row">
+        <strong>${r.estado}</strong> · método: ${r.metodo || "-"}<br/>
+        intento: ${fmt(r.hora_intento)}<br/>
+        dormido: ${fmt(r.hora_sueno_efectivo)} · despertó: ${fmt(r.hora_despertar)}
+      </div>
+    `)
+    .join("");
+}
+
+async function loadAnaliticas() {
+  const userId = v("userId");
+  if (!userId) return;
+
+  const res = await fetch(`/api/analiticas?user_id=${encodeURIComponent(userId)}&tz=${encodeURIComponent(tz)}`);
+  const data = await res.json();
+  if (!res.ok) return;
+
+  document.getElementById("stat-registros").textContent = String(data.registros);
+  document.getElementById("stat-latencia").textContent = `${data.latencia_media_min} min`;
+  document.getElementById("stat-sueno").textContent = formatMinutes(data.sueno_total_min);
+}
+
+function v(id) {
+  return document.getElementById(id).value.trim();
+}
+
+function dt(id) {
+  const raw = document.getElementById(id).value;
+  return raw ? new Date(raw).toISOString() : null;
+}
+
+function fmt(value) {
+  if (!value) return "-";
+  return new Date(value).toLocaleString("es-ES");
+}
+
+function formatMinutes(min) {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return h ? `${h} h ${m} min` : `${m} min`;
+}
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch(() => {});
+  });
+}

--- a/d1_schema.sql
+++ b/d1_schema.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS registros_sueno (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  estado TEXT NOT NULL CHECK (estado IN ('PENDIENTE_DORMIR', 'DURMIENDO', 'FINALIZADO')),
+  hora_intento TEXT NOT NULL,
+  hora_sueno_efectivo TEXT,
+  hora_despertar TEXT,
+  metodo TEXT CHECK (metodo IN ('brazos', 'cuna', 'acunada')),
+  user_id TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_registros_sueno_user_estado
+  ON registros_sueno (user_id, estado);
+
+CREATE INDEX IF NOT EXISTS idx_registros_sueno_user_hora_intento
+  ON registros_sueno (user_id, hora_intento);

--- a/functions/api/analiticas.js
+++ b/functions/api/analiticas.js
@@ -1,0 +1,105 @@
+export async function onRequest(context) {
+  if (context.request.method !== "GET") {
+    return json({ error: "Método no permitido" }, 405);
+  }
+
+  const url = new URL(context.request.url);
+  const userId = url.searchParams.get("user_id");
+  const tz = url.searchParams.get("tz") || "Europe/Madrid";
+
+  if (!userId) {
+    return json({ error: "user_id es obligatorio" }, 400);
+  }
+
+  const start = startOfDayUtc(new Date(), tz);
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+
+  const { results } = await context.env.DB.prepare(
+    `SELECT hora_intento, hora_sueno_efectivo, hora_despertar
+     FROM registros_sueno
+     WHERE user_id = ?
+       AND hora_intento >= ?
+       AND hora_intento < ?`
+  )
+    .bind(userId, start.toISOString(), end.toISOString())
+    .all();
+
+  const rows = results || [];
+  let latenciaTotal = 0;
+  let latenciaN = 0;
+  let suenoTotal = 0;
+
+  for (const row of rows) {
+    if (row.hora_intento && row.hora_sueno_efectivo) {
+      latenciaTotal += diffMinutes(new Date(row.hora_intento), new Date(row.hora_sueno_efectivo));
+      latenciaN += 1;
+    }
+    if (row.hora_sueno_efectivo && row.hora_despertar) {
+      suenoTotal += diffMinutes(new Date(row.hora_sueno_efectivo), new Date(row.hora_despertar));
+    }
+  }
+
+  return json({
+    fecha: start.toISOString(),
+    registros: rows.length,
+    latencia_media_min: latenciaN ? Math.round(latenciaTotal / latenciaN) : 0,
+    sueno_total_min: suenoTotal,
+  });
+}
+
+function diffMinutes(start, end) {
+  return Math.max(0, Math.round((end.getTime() - start.getTime()) / 60000));
+}
+
+function zonedParts(date, timeZone) {
+  const dtf = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = Object.fromEntries(dtf.formatToParts(date).filter(p => p.type !== "literal").map(p => [p.type, p.value]));
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+  };
+}
+
+function getOffsetMs(date, timeZone) {
+  const dtf = new Intl.DateTimeFormat("en-GB", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const p = Object.fromEntries(dtf.formatToParts(date).filter(x => x.type !== "literal").map(x => [x.type, x.value]));
+  const asUtc = Date.UTC(Number(p.year), Number(p.month) - 1, Number(p.day), Number(p.hour), Number(p.minute), Number(p.second));
+  return asUtc - date.getTime();
+}
+
+function zonedDateTimeToUtc(y, m, d, hh, mm, ss, timeZone) {
+  const guess = Date.UTC(y, m - 1, d, hh, mm, ss);
+  const offset = getOffsetMs(new Date(guess), timeZone);
+  return new Date(guess - offset);
+}
+
+function startOfDayUtc(date, timeZone) {
+  const p = zonedParts(date, timeZone);
+  return zonedDateTimeToUtc(p.year, p.month, p.day, 0, 0, 0, timeZone);
+}
+
+function json(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/functions/api/registros.js
+++ b/functions/api/registros.js
@@ -1,0 +1,87 @@
+const ESTADOS = ["PENDIENTE_DORMIR", "DURMIENDO", "FINALIZADO"];
+const METODOS = ["brazos", "cuna", "acunada"];
+
+export async function onRequest(context) {
+  const { request } = context;
+
+  if (request.method === "GET") {
+    return handleGet(context);
+  }
+
+  if (request.method === "POST") {
+    return handlePost(context);
+  }
+
+  return json({ error: "Método no permitido" }, 405);
+}
+
+async function handleGet({ request, env }) {
+  const url = new URL(request.url);
+  const userId = url.searchParams.get("user_id");
+  const desde = url.searchParams.get("desde");
+  const hasta = url.searchParams.get("hasta");
+
+  if (!userId) {
+    return json({ error: "user_id es obligatorio" }, 400);
+  }
+
+  const { results } = await env.DB.prepare(
+    `SELECT id, estado, hora_intento, hora_sueno_efectivo, hora_despertar, metodo, user_id
+     FROM registros_sueno
+     WHERE user_id = ?
+       AND (? IS NULL OR hora_intento >= ?)
+       AND (? IS NULL OR hora_intento < ?)
+     ORDER BY hora_intento DESC`
+  )
+    .bind(userId, desde, desde, hasta, hasta)
+    .all();
+
+  return json({ data: results || [] });
+}
+
+async function handlePost({ request, env }) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "JSON inválido" }, 400);
+  }
+
+  const {
+    user_id,
+    estado = "FINALIZADO",
+    hora_intento,
+    hora_sueno_efectivo,
+    hora_despertar,
+    metodo = null,
+  } = body;
+
+  if (!user_id || !hora_intento) {
+    return json({ error: "user_id y hora_intento son obligatorios" }, 400);
+  }
+
+  if (!ESTADOS.includes(estado)) {
+    return json({ error: "estado no válido" }, 400);
+  }
+
+  if (metodo && !METODOS.includes(metodo)) {
+    return json({ error: "metodo no válido" }, 400);
+  }
+
+  const result = await env.DB.prepare(
+    `INSERT INTO registros_sueno
+      (estado, hora_intento, hora_sueno_efectivo, hora_despertar, metodo, user_id)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  )
+    .bind(estado, hora_intento, hora_sueno_efectivo || null, hora_despertar || null, metodo, user_id)
+    .run();
+
+  return json({ ok: true, id: result.meta?.last_row_id ?? null }, 201);
+}
+
+function json(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,96 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#4f46e5" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="stylesheet" href="/styles.css" />
+    <title>Sleep Tracker PWA</title>
+  </head>
+  <body>
+    <main class="app">
+      <header class="header">
+        <h1>🍼 Sleep Tracker</h1>
+        <p>Mide latencia y sueño efectivo desde Cloudflare Pages + D1</p>
+      </header>
+
+      <section id="tab-registro" class="tab-content active">
+        <form id="registro-form" class="card">
+          <h2>Registro</h2>
+
+          <label>User ID
+            <input id="userId" type="text" placeholder="Ej: mama_001" required />
+          </label>
+
+          <label>Estado
+            <select id="estado">
+              <option value="PENDIENTE_DORMIR">PENDIENTE_DORMIR</option>
+              <option value="DURMIENDO">DURMIENDO</option>
+              <option value="FINALIZADO" selected>FINALIZADO</option>
+            </select>
+          </label>
+
+          <label>Hora intento
+            <input id="horaIntento" type="datetime-local" required />
+          </label>
+
+          <label>Hora sueño efectivo
+            <input id="horaDormido" type="datetime-local" />
+          </label>
+
+          <label>Hora despertar
+            <input id="horaDespertar" type="datetime-local" />
+          </label>
+
+          <label>Método
+            <select id="metodo">
+              <option value="">(sin método)</option>
+              <option value="brazos">brazos</option>
+              <option value="cuna">cuna</option>
+              <option value="acunada">acunada</option>
+            </select>
+          </label>
+
+          <button type="submit">Guardar registro</button>
+          <p id="form-msg"></p>
+        </form>
+
+        <section class="card">
+          <h2>Últimos registros</h2>
+          <button id="reload-registros" type="button">Recargar</button>
+          <div id="registros-lista" class="list"></div>
+        </section>
+      </section>
+
+      <section id="tab-analiticas" class="tab-content">
+        <div class="card">
+          <h2>Analíticas de hoy</h2>
+          <p>Zona horaria: <strong id="tz-text"></strong></p>
+          <button id="reload-analiticas" type="button">Actualizar analíticas</button>
+          <div class="stats">
+            <article>
+              <h3>Registros</h3>
+              <p id="stat-registros">0</p>
+            </article>
+            <article>
+              <h3>Latencia media</h3>
+              <p id="stat-latencia">0 min</p>
+            </article>
+            <article>
+              <h3>Sueño total</h3>
+              <p id="stat-sueno">0 min</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <nav class="bottom-nav">
+      <button id="tab-btn-registro" class="active">Registro</button>
+      <button id="tab-btn-analiticas">Analíticas</button>
+    </nav>
+
+    <script src="/app.js" type="module"></script>
+  </body>
+</html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,10 @@
+{
+  "name": "Sleep Tracker PWA",
+  "short_name": "SleepTracker",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f3f4f6",
+  "theme_color": "#4f46e5",
+  "lang": "es",
+  "icons": []
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,76 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; background: #f3f4f6; color: #111827; }
+.app { padding: 1rem; padding-bottom: 5.5rem; max-width: 720px; margin: 0 auto; }
+.header h1 { margin: 0; }
+.header p { margin-top: .2rem; color: #4b5563; }
+.card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1rem;
+  margin-top: 1rem;
+  box-shadow: 0 4px 20px rgba(0,0,0,.06);
+}
+label { display: block; margin: .7rem 0; font-weight: 600; }
+input, select, button {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: .65rem .75rem;
+  margin-top: .3rem;
+  font: inherit;
+}
+button {
+  background: #4f46e5;
+  color: #fff;
+  border: none;
+  font-weight: 700;
+}
+button:active { transform: scale(.99); }
+#form-msg { font-size: .95rem; min-height: 1.2rem; }
+.list .row {
+  border-bottom: 1px solid #e5e7eb;
+  padding: .65rem 0;
+  font-size: .92rem;
+}
+.list .row:last-child { border-bottom: none; }
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: .7rem;
+  margin-top: .8rem;
+}
+.stats article {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: .75rem;
+  text-align: center;
+}
+.stats h3 { margin: 0; font-size: .82rem; color: #4b5563; }
+.stats p { margin: .35rem 0 0; font-size: 1.05rem; font-weight: 800; }
+
+.tab-content { display: none; }
+.tab-content.active { display: block; }
+
+.bottom-nav {
+  position: fixed;
+  left: 0; right: 0; bottom: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: .5rem;
+  padding: .6rem;
+  background: #fff;
+  border-top: 1px solid #e5e7eb;
+}
+.bottom-nav button {
+  background: #e5e7eb;
+  color: #111827;
+}
+.bottom-nav button.active {
+  background: #4f46e5;
+  color: #fff;
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,29 @@
+const CACHE = "sleep-tracker-v1";
+const ASSETS = ["/", "/index.html", "/styles.css", "/app.js", "/manifest.webmanifest"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(ASSETS)));
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.method !== "GET") return;
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request)
+        .then((response) => {
+          const copy = response.clone();
+          caches.open(CACHE).then((cache) => cache.put(event.request, copy));
+          return response;
+        })
+        .catch(() => caches.match("/index.html"));
+    })
+  );
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,8 @@
+name = "sleep-tracker-pwa"
+compatibility_date = "2026-04-17"
+pages_build_output_dir = "."
+
+[[d1_databases]]
+binding = "DB"
+database_name = "sleep-tracker"
+database_id = "REEMPLAZAR_CON_TU_DATABASE_ID"


### PR DESCRIPTION
## Qué cambié
- Reemplacé la implementación del bot de Telegram por una PWA para Cloudflare Pages.
- Añadí interfaz frontal con:
  - pestaña **Registro** (izquierda en menú inferior),
  - pestaña **Analíticas** (derecha en menú inferior).
- Añadí backend serverless en Pages Functions para acceso a D1 desde la misma app:
  - `GET/POST /api/registros`
  - `GET /api/analiticas`
- Configuré assets PWA:
  - `manifest.webmanifest`
  - `sw.js` (cache básico offline)
- Añadí `wrangler.toml` con binding D1 (`DB`).
- Actualicé `d1_schema.sql` dejando la tabla `registros_sueno` con índices útiles.
- Eliminé `worker.js` (flujo Telegram) para alinear con el nuevo requerimiento.

## UX solicitada
- Menú inferior con dos botones:
  - **Registro** (izquierda)
  - **Analíticas** (derecha)
- Registro de datos de sueño (estado, horas, método, user_id).
- Analíticas del día: número de registros, latencia media y sueño total.

## Validación
- `node --check app.js`
- `node --check functions/api/registros.js`
- `node --check functions/api/analiticas.js`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e267d0c0b88322a74eaf5543a6385c)