### PR TITLE
Admin de reservas: calendario por reserva, gestión de slots y cierre económico (VipVan Madrid)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,148 @@
+const mockReservations = [
+  {
+    id: 'RES-2026-0506',
+    status: 'reservado_con_senal',
+    bookingType: 'daily_partial',
+    vehicleId: 'v300d',
+    customer: { name: 'Marta Gil', phone: '+34 600 123 123' },
+    payment: { depositPaid: 224, finalTotal: 560, pending: 336 },
+    occupancy: {
+      '2026-05-10': { mode: 'partial', slots: [
+        { id: 's1', start: '12:00', end: '14:00' },
+        { id: 's2', start: '17:00', end: '20:00' }
+      ] },
+      '2026-05-11': { mode: 'partial', slots: [
+        { id: 's3', start: '09:00', end: '11:00' }
+      ] }
+    }
+  },
+  {
+    id: 'RES-2026-0510',
+    status: 'reservado_con_senal',
+    bookingType: 'daily_full',
+    vehicleId: 'sprinter-lux',
+    customer: { name: 'Grupo Atlas', phone: '+34 600 999 001' },
+    payment: { depositPaid: 500, finalTotal: 1800, pending: 1300 },
+    occupancy: {
+      '2026-05-14': { mode: 'full_day', slots: [] },
+      '2026-05-15': { mode: 'full_day', slots: [] },
+      '2026-05-16': { mode: 'full_day', slots: [] }
+    }
+  },
+  {
+    id: 'RES-2026-0520',
+    status: 'confirmada',
+    bookingType: 'hourly',
+    vehicleId: 'v-class',
+    customer: { name: 'Lucía Flores', phone: '+34 600 000 777' },
+    payment: { depositPaid: 150, finalTotal: 350, pending: 0 },
+    occupancy: { '2026-05-20': { mode: 'partial', slots: [{ id: 's4', start: '10:00', end: '13:00' }] } }
+  },
+  {
+    id: 'RES-2026-0530',
+    status: 'cancelada',
+    bookingType: 'daily_partial',
+    vehicleId: 'vito',
+    customer: { name: 'Carlos Redondo', phone: '+34 600 222 333' },
+    payment: { depositPaid: 100, finalTotal: 300, pending: 200 },
+    occupancy: {}
+  }
+];
+
+const state = { reservations: mockReservations, selectedReservationId: mockReservations[0].id, selectedDate: null, currentMonth: new Date('2026-05-01') };
+const els = {
+  reservationList: document.getElementById('reservation-list'), calendar: document.getElementById('calendar'), calendarMonth: document.getElementById('calendar-month'),
+  reservationTitle: document.getElementById('reservation-title'), reservationMeta: document.getElementById('reservation-meta'), selectedDayTitle: document.getElementById('selected-day-title'),
+  daySlots: document.getElementById('day-slots'), financeBox: document.getElementById('finance-box'), hourCheckboxes: document.getElementById('hour-checkboxes')
+};
+
+const getReservation = () => state.reservations.find(r => r.id === state.selectedReservationId);
+const pad = n => String(n).padStart(2, '0');
+const dateKey = d => `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+const getDayMode = (reservation, day) => reservation.occupancy[day]?.mode ?? 'free';
+
+function addSlot(reservation, day, slot) {
+  if (!reservation.occupancy[day] || reservation.occupancy[day].mode === 'full_day') reservation.occupancy[day] = { mode: 'partial', slots: [] };
+  reservation.occupancy[day].slots.push({ ...slot, id: crypto.randomUUID() });
+}
+function ensureFullDay(reservation, day) { reservation.occupancy[day] = { mode: 'full_day', slots: [] }; }
+function clearDay(reservation, day) { delete reservation.occupancy[day]; }
+function removeSlot(reservation, day, slotId) {
+  const dayData = reservation.occupancy[day]; if (!dayData || dayData.mode !== 'partial') return;
+  dayData.slots = dayData.slots.filter(s => s.id !== slotId); if (!dayData.slots.length) delete reservation.occupancy[day];
+}
+
+function renderReservationList() {
+  els.reservationList.innerHTML = state.reservations.map(r => `<li class="reservation-item ${r.id===state.selectedReservationId?'active':''}" data-id="${r.id}"><strong>${r.id}</strong><div>${r.customer.name}</div><div class="status">${r.status}</div></li>`).join('');
+}
+function renderCalendar() {
+  const res = getReservation();
+  const y = state.currentMonth.getFullYear(); const m = state.currentMonth.getMonth();
+  els.calendarMonth.textContent = state.currentMonth.toLocaleDateString('es-ES', { month: 'long', year: 'numeric' });
+  const days = new Date(y, m+1, 0).getDate();
+  els.calendar.innerHTML = Array.from({ length: days }, (_, i) => {
+    const d = new Date(y,m,i+1); const key = dateKey(d); const mode = getDayMode(res,key); const sel = state.selectedDate===key?'selected':'';
+    return `<button class="day-cell ${mode} ${sel}" data-day="${key}"><div>${i+1}</div><small>${mode}</small></button>`;
+  }).join('');
+}
+function renderDayEditor() {
+  const res = getReservation();
+  const day = state.selectedDate;
+  els.selectedDayTitle.textContent = day ? `Día seleccionado: ${day}` : 'Selecciona un día';
+  if (!day) { els.daySlots.innerHTML = ''; return; }
+  const dayData = res.occupancy[day];
+  if (!dayData) { els.daySlots.innerHTML = '<li>Sin slots (libre)</li>'; return; }
+  if (dayData.mode === 'full_day') { els.daySlots.innerHTML = '<li>Día completo ocupado (sin slots horarios)</li>'; return; }
+  els.daySlots.innerHTML = dayData.slots.map(s => `<li class="slot-item"><span>${s.start} - ${s.end}</span><button data-slot-id="${s.id}">Eliminar</button></li>`).join('');
+}
+function renderFinance() {
+  const r = getReservation();
+  r.payment.pending = Math.max(r.payment.finalTotal - r.payment.depositPaid, 0);
+  els.financeBox.innerHTML = `
+  <div class="finance-row"><span>Estado</span><strong>${r.status}</strong></div>
+  <div class="finance-row"><span>Señal pagada</span><strong>${r.payment.depositPaid}€</strong></div>
+  <label>Total final <input id="final-total" type="number" min="0" value="${r.payment.finalTotal}" /></label>
+  <div class="finance-row"><span>Pendiente</span><strong id="pending-amount">${r.payment.pending}€</strong></div>
+  <button id="mock-link" type="button">Generar enlace de pago mock</button>
+  <small id="mock-link-out"></small>
+  <button id="mark-paid" type="button">Marcar pago recibido</button>`;
+}
+function renderHourCheckboxes() {
+  els.hourCheckboxes.innerHTML = Array.from({ length: 24 }, (_,h)=>`<label><input type="checkbox" value="${pad(h)}"/>${pad(h)}:00</label>`).join('');
+}
+function renderAll(){ renderReservationList(); renderCalendar(); renderDayEditor(); renderFinance(); renderHourCheckboxes();
+  const r = getReservation(); els.reservationTitle.textContent = `${r.id} · ${r.customer.name}`; els.reservationMeta.textContent = `${r.bookingType} · Vehículo ${r.vehicleId}`;
+}
+
+document.addEventListener('click', (e) => {
+  const t = e.target;
+  if (t.closest('.reservation-item')) { state.selectedReservationId = t.closest('.reservation-item').dataset.id; state.selectedDate = null; renderAll(); }
+  if (t.closest('.day-cell')) { state.selectedDate = t.closest('.day-cell').dataset.day; renderAll(); }
+  if (t.id === 'prev-month') { state.currentMonth = new Date(state.currentMonth.getFullYear(), state.currentMonth.getMonth()-1, 1); renderCalendar(); }
+  if (t.id === 'next-month') { state.currentMonth = new Date(state.currentMonth.getFullYear(), state.currentMonth.getMonth()+1, 1); renderCalendar(); }
+  if (t.id === 'mark-full-day' && state.selectedDate) { ensureFullDay(getReservation(), state.selectedDate); renderAll(); }
+  if (t.id === 'free-day' && state.selectedDate) { clearDay(getReservation(), state.selectedDate); renderAll(); }
+  if (t.id === 'add-checked-hours' && state.selectedDate) {
+    const selected = [...document.querySelectorAll('#hour-checkboxes input:checked')].map(i=>Number(i.value)).sort((a,b)=>a-b);
+    selected.forEach(h => addSlot(getReservation(), state.selectedDate, { start: `${pad(h)}:00`, end: `${pad((h+1)%24)}:00` }));
+    renderAll();
+  }
+  if (t.id === 'add-manual-range' && state.selectedDate) {
+    const start = document.getElementById('manual-start').value; const end = document.getElementById('manual-end').value;
+    if (start && end && start < end) addSlot(getReservation(), state.selectedDate, { start, end });
+    renderAll();
+  }
+  if (t.dataset.slotId && state.selectedDate) { removeSlot(getReservation(), state.selectedDate, t.dataset.slotId); renderAll(); }
+  if (t.id === 'mock-link') {
+    const r = getReservation(); document.getElementById('mock-link-out').textContent = `https://pay.vipvan.mock/${r.id}/${Date.now()}`;
+  }
+  if (t.id === 'mark-paid') {
+    const r = getReservation(); r.payment.depositPaid = r.payment.finalTotal; r.payment.pending = 0; r.status = 'confirmada'; renderAll();
+  }
+});
+
+document.addEventListener('input', (e) => {
+  if (e.target.id === 'final-total') { const r = getReservation(); r.payment.finalTotal = Number(e.target.value || 0); r.payment.pending = Math.max(r.payment.finalTotal - r.payment.depositPaid, 0); renderFinance(); }
+});
+
+renderAll();

--- a/dist/app.js
+++ b/dist/app.js
@@ -1,0 +1,148 @@
+const mockReservations = [
+  {
+    id: 'RES-2026-0506',
+    status: 'reservado_con_senal',
+    bookingType: 'daily_partial',
+    vehicleId: 'v300d',
+    customer: { name: 'Marta Gil', phone: '+34 600 123 123' },
+    payment: { depositPaid: 224, finalTotal: 560, pending: 336 },
+    occupancy: {
+      '2026-05-10': { mode: 'partial', slots: [
+        { id: 's1', start: '12:00', end: '14:00' },
+        { id: 's2', start: '17:00', end: '20:00' }
+      ] },
+      '2026-05-11': { mode: 'partial', slots: [
+        { id: 's3', start: '09:00', end: '11:00' }
+      ] }
+    }
+  },
+  {
+    id: 'RES-2026-0510',
+    status: 'reservado_con_senal',
+    bookingType: 'daily_full',
+    vehicleId: 'sprinter-lux',
+    customer: { name: 'Grupo Atlas', phone: '+34 600 999 001' },
+    payment: { depositPaid: 500, finalTotal: 1800, pending: 1300 },
+    occupancy: {
+      '2026-05-14': { mode: 'full_day', slots: [] },
+      '2026-05-15': { mode: 'full_day', slots: [] },
+      '2026-05-16': { mode: 'full_day', slots: [] }
+    }
+  },
+  {
+    id: 'RES-2026-0520',
+    status: 'confirmada',
+    bookingType: 'hourly',
+    vehicleId: 'v-class',
+    customer: { name: 'Lucía Flores', phone: '+34 600 000 777' },
+    payment: { depositPaid: 150, finalTotal: 350, pending: 0 },
+    occupancy: { '2026-05-20': { mode: 'partial', slots: [{ id: 's4', start: '10:00', end: '13:00' }] } }
+  },
+  {
+    id: 'RES-2026-0530',
+    status: 'cancelada',
+    bookingType: 'daily_partial',
+    vehicleId: 'vito',
+    customer: { name: 'Carlos Redondo', phone: '+34 600 222 333' },
+    payment: { depositPaid: 100, finalTotal: 300, pending: 200 },
+    occupancy: {}
+  }
+];
+
+const state = { reservations: mockReservations, selectedReservationId: mockReservations[0].id, selectedDate: null, currentMonth: new Date('2026-05-01') };
+const els = {
+  reservationList: document.getElementById('reservation-list'), calendar: document.getElementById('calendar'), calendarMonth: document.getElementById('calendar-month'),
+  reservationTitle: document.getElementById('reservation-title'), reservationMeta: document.getElementById('reservation-meta'), selectedDayTitle: document.getElementById('selected-day-title'),
+  daySlots: document.getElementById('day-slots'), financeBox: document.getElementById('finance-box'), hourCheckboxes: document.getElementById('hour-checkboxes')
+};
+
+const getReservation = () => state.reservations.find(r => r.id === state.selectedReservationId);
+const pad = n => String(n).padStart(2, '0');
+const dateKey = d => `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+const getDayMode = (reservation, day) => reservation.occupancy[day]?.mode ?? 'free';
+
+function addSlot(reservation, day, slot) {
+  if (!reservation.occupancy[day] || reservation.occupancy[day].mode === 'full_day') reservation.occupancy[day] = { mode: 'partial', slots: [] };
+  reservation.occupancy[day].slots.push({ ...slot, id: crypto.randomUUID() });
+}
+function ensureFullDay(reservation, day) { reservation.occupancy[day] = { mode: 'full_day', slots: [] }; }
+function clearDay(reservation, day) { delete reservation.occupancy[day]; }
+function removeSlot(reservation, day, slotId) {
+  const dayData = reservation.occupancy[day]; if (!dayData || dayData.mode !== 'partial') return;
+  dayData.slots = dayData.slots.filter(s => s.id !== slotId); if (!dayData.slots.length) delete reservation.occupancy[day];
+}
+
+function renderReservationList() {
+  els.reservationList.innerHTML = state.reservations.map(r => `<li class="reservation-item ${r.id===state.selectedReservationId?'active':''}" data-id="${r.id}"><strong>${r.id}</strong><div>${r.customer.name}</div><div class="status">${r.status}</div></li>`).join('');
+}
+function renderCalendar() {
+  const res = getReservation();
+  const y = state.currentMonth.getFullYear(); const m = state.currentMonth.getMonth();
+  els.calendarMonth.textContent = state.currentMonth.toLocaleDateString('es-ES', { month: 'long', year: 'numeric' });
+  const days = new Date(y, m+1, 0).getDate();
+  els.calendar.innerHTML = Array.from({ length: days }, (_, i) => {
+    const d = new Date(y,m,i+1); const key = dateKey(d); const mode = getDayMode(res,key); const sel = state.selectedDate===key?'selected':'';
+    return `<button class="day-cell ${mode} ${sel}" data-day="${key}"><div>${i+1}</div><small>${mode}</small></button>`;
+  }).join('');
+}
+function renderDayEditor() {
+  const res = getReservation();
+  const day = state.selectedDate;
+  els.selectedDayTitle.textContent = day ? `Día seleccionado: ${day}` : 'Selecciona un día';
+  if (!day) { els.daySlots.innerHTML = ''; return; }
+  const dayData = res.occupancy[day];
+  if (!dayData) { els.daySlots.innerHTML = '<li>Sin slots (libre)</li>'; return; }
+  if (dayData.mode === 'full_day') { els.daySlots.innerHTML = '<li>Día completo ocupado (sin slots horarios)</li>'; return; }
+  els.daySlots.innerHTML = dayData.slots.map(s => `<li class="slot-item"><span>${s.start} - ${s.end}</span><button data-slot-id="${s.id}">Eliminar</button></li>`).join('');
+}
+function renderFinance() {
+  const r = getReservation();
+  r.payment.pending = Math.max(r.payment.finalTotal - r.payment.depositPaid, 0);
+  els.financeBox.innerHTML = `
+  <div class="finance-row"><span>Estado</span><strong>${r.status}</strong></div>
+  <div class="finance-row"><span>Señal pagada</span><strong>${r.payment.depositPaid}€</strong></div>
+  <label>Total final <input id="final-total" type="number" min="0" value="${r.payment.finalTotal}" /></label>
+  <div class="finance-row"><span>Pendiente</span><strong id="pending-amount">${r.payment.pending}€</strong></div>
+  <button id="mock-link" type="button">Generar enlace de pago mock</button>
+  <small id="mock-link-out"></small>
+  <button id="mark-paid" type="button">Marcar pago recibido</button>`;
+}
+function renderHourCheckboxes() {
+  els.hourCheckboxes.innerHTML = Array.from({ length: 24 }, (_,h)=>`<label><input type="checkbox" value="${pad(h)}"/>${pad(h)}:00</label>`).join('');
+}
+function renderAll(){ renderReservationList(); renderCalendar(); renderDayEditor(); renderFinance(); renderHourCheckboxes();
+  const r = getReservation(); els.reservationTitle.textContent = `${r.id} · ${r.customer.name}`; els.reservationMeta.textContent = `${r.bookingType} · Vehículo ${r.vehicleId}`;
+}
+
+document.addEventListener('click', (e) => {
+  const t = e.target;
+  if (t.closest('.reservation-item')) { state.selectedReservationId = t.closest('.reservation-item').dataset.id; state.selectedDate = null; renderAll(); }
+  if (t.closest('.day-cell')) { state.selectedDate = t.closest('.day-cell').dataset.day; renderAll(); }
+  if (t.id === 'prev-month') { state.currentMonth = new Date(state.currentMonth.getFullYear(), state.currentMonth.getMonth()-1, 1); renderCalendar(); }
+  if (t.id === 'next-month') { state.currentMonth = new Date(state.currentMonth.getFullYear(), state.currentMonth.getMonth()+1, 1); renderCalendar(); }
+  if (t.id === 'mark-full-day' && state.selectedDate) { ensureFullDay(getReservation(), state.selectedDate); renderAll(); }
+  if (t.id === 'free-day' && state.selectedDate) { clearDay(getReservation(), state.selectedDate); renderAll(); }
+  if (t.id === 'add-checked-hours' && state.selectedDate) {
+    const selected = [...document.querySelectorAll('#hour-checkboxes input:checked')].map(i=>Number(i.value)).sort((a,b)=>a-b);
+    selected.forEach(h => addSlot(getReservation(), state.selectedDate, { start: `${pad(h)}:00`, end: `${pad((h+1)%24)}:00` }));
+    renderAll();
+  }
+  if (t.id === 'add-manual-range' && state.selectedDate) {
+    const start = document.getElementById('manual-start').value; const end = document.getElementById('manual-end').value;
+    if (start && end && start < end) addSlot(getReservation(), state.selectedDate, { start, end });
+    renderAll();
+  }
+  if (t.dataset.slotId && state.selectedDate) { removeSlot(getReservation(), state.selectedDate, t.dataset.slotId); renderAll(); }
+  if (t.id === 'mock-link') {
+    const r = getReservation(); document.getElementById('mock-link-out').textContent = `https://pay.vipvan.mock/${r.id}/${Date.now()}`;
+  }
+  if (t.id === 'mark-paid') {
+    const r = getReservation(); r.payment.depositPaid = r.payment.finalTotal; r.payment.pending = 0; r.status = 'confirmada'; renderAll();
+  }
+});
+
+document.addEventListener('input', (e) => {
+  if (e.target.id === 'final-total') { const r = getReservation(); r.payment.finalTotal = Number(e.target.value || 0); r.payment.pending = Math.max(r.payment.finalTotal - r.payment.depositPaid, 0); renderFinance(); }
+});
+
+renderAll();

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>VipVan Madrid · Admin de reservas</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>VipVan Madrid · Administración de reservas</h1>
+  </header>
+
+  <main class="layout">
+    <aside class="panel reservations-panel">
+      <h2>Reservas</h2>
+      <ul id="reservation-list" class="reservation-list"></ul>
+    </aside>
+
+    <section class="panel editor-panel">
+      <div class="editor-header">
+        <h2 id="reservation-title">Selecciona una reserva</h2>
+        <p id="reservation-meta" class="muted"></p>
+      </div>
+
+      <div class="month-nav">
+        <button id="prev-month" type="button">← Mes anterior</button>
+        <h3 id="calendar-month"></h3>
+        <button id="next-month" type="button">Mes siguiente →</button>
+      </div>
+
+      <div id="calendar" class="calendar"></div>
+
+      <section class="day-editor">
+        <h3 id="selected-day-title">Selecciona un día</h3>
+        <div class="actions-row">
+          <button id="mark-full-day" type="button">Marcar día completo</button>
+          <button id="free-day" type="button" class="danger">Liberar todo el día</button>
+        </div>
+
+        <div class="slot-creator">
+          <h4>Añadir slots por horas (checkboxes)</h4>
+          <div id="hour-checkboxes" class="hour-grid"></div>
+          <button id="add-checked-hours" type="button">Añadir horas seleccionadas</button>
+        </div>
+
+        <div class="slot-creator">
+          <h4>Añadir slot manual por rango</h4>
+          <div class="manual-range">
+            <label>Inicio <input id="manual-start" type="time" /></label>
+            <label>Fin <input id="manual-end" type="time" /></label>
+            <button id="add-manual-range" type="button">Añadir rango</button>
+          </div>
+        </div>
+
+        <div>
+          <h4>Slots cerrados del día</h4>
+          <ul id="day-slots" class="slot-list"></ul>
+        </div>
+      </section>
+    </section>
+
+    <aside class="panel finance-panel">
+      <h2>Cierre económico</h2>
+      <div id="finance-box" class="finance-box"></div>
+    </aside>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,0 +1,26 @@
+:root { font-family: Arial, sans-serif; color-scheme: light; }
+body { margin: 0; background: #f4f6f8; color: #1d2430; }
+header { background: #152238; color: #fff; padding: 1rem 1.5rem; }
+.layout { display: grid; grid-template-columns: 280px 1fr 320px; gap: 1rem; padding: 1rem; }
+.panel { background: #fff; border-radius: 8px; padding: 1rem; box-shadow: 0 1px 4px rgba(0,0,0,.1); }
+.reservation-list { list-style: none; padding: 0; margin: 0; display: grid; gap: .5rem; }
+.reservation-item { border: 1px solid #d9e0e8; border-radius: 6px; padding: .5rem; cursor: pointer; }
+.reservation-item.active { border-color: #0f62fe; background: #edf4ff; }
+.status { font-size: .8rem; color: #4f596b; }
+.month-nav { display: flex; justify-content: space-between; align-items: center; }
+.calendar { display: grid; grid-template-columns: repeat(7, 1fr); gap: .4rem; margin-bottom: 1rem; }
+.day-cell { border: 1px solid #d9e0e8; border-radius: 6px; min-height: 70px; padding: .3rem; cursor: pointer; }
+.day-cell.full_day { background: #ffd8d8; }
+.day-cell.partial { background: #fff2c6; }
+.day-cell.free { background: #e6f6ea; }
+.day-cell.selected { outline: 2px solid #0f62fe; }
+.hour-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: .3rem; margin-bottom: .5rem; }
+.slot-list { list-style: none; padding: 0; margin: 0; display: grid; gap: .4rem; }
+.slot-item { border: 1px solid #d9e0e8; border-radius: 6px; padding: .4rem; display: flex; justify-content: space-between; }
+.actions-row, .manual-range { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: .8rem; }
+button { cursor: pointer; border: 1px solid #bcc7d6; border-radius: 6px; padding: .4rem .6rem; background: #fff; }
+button.danger { border-color: #cc2c2c; color: #cc2c2c; }
+.muted { color: #4f596b; }
+.finance-box { display: grid; gap: .6rem; }
+.finance-row { display: flex; justify-content: space-between; }
+@media (max-width: 1200px) { .layout { grid-template-columns: 1fr; } }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>VipVan Madrid · Admin de reservas</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>VipVan Madrid · Administración de reservas</h1>
+  </header>
+
+  <main class="layout">
+    <aside class="panel reservations-panel">
+      <h2>Reservas</h2>
+      <ul id="reservation-list" class="reservation-list"></ul>
+    </aside>
+
+    <section class="panel editor-panel">
+      <div class="editor-header">
+        <h2 id="reservation-title">Selecciona una reserva</h2>
+        <p id="reservation-meta" class="muted"></p>
+      </div>
+
+      <div class="month-nav">
+        <button id="prev-month" type="button">← Mes anterior</button>
+        <h3 id="calendar-month"></h3>
+        <button id="next-month" type="button">Mes siguiente →</button>
+      </div>
+
+      <div id="calendar" class="calendar"></div>
+
+      <section class="day-editor">
+        <h3 id="selected-day-title">Selecciona un día</h3>
+        <div class="actions-row">
+          <button id="mark-full-day" type="button">Marcar día completo</button>
+          <button id="free-day" type="button" class="danger">Liberar todo el día</button>
+        </div>
+
+        <div class="slot-creator">
+          <h4>Añadir slots por horas (checkboxes)</h4>
+          <div id="hour-checkboxes" class="hour-grid"></div>
+          <button id="add-checked-hours" type="button">Añadir horas seleccionadas</button>
+        </div>
+
+        <div class="slot-creator">
+          <h4>Añadir slot manual por rango</h4>
+          <div class="manual-range">
+            <label>Inicio <input id="manual-start" type="time" /></label>
+            <label>Fin <input id="manual-end" type="time" /></label>
+            <button id="add-manual-range" type="button">Añadir rango</button>
+          </div>
+        </div>
+
+        <div>
+          <h4>Slots cerrados del día</h4>
+          <ul id="day-slots" class="slot-list"></ul>
+        </div>
+      </section>
+    </section>
+
+    <aside class="panel finance-panel">
+      <h2>Cierre económico</h2>
+      <div id="finance-box" class="finance-box"></div>
+    </aside>
+  </main>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "vipvan-madrid-admin-reservas",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "echo 'Build estático completado'"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "echo 'Build estático completado'"
+    "build": "rm -rf dist && mkdir -p dist && cp index.html styles.css app.js dist/ && echo 'Build estático completado en dist/'"
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,26 @@
+:root { font-family: Arial, sans-serif; color-scheme: light; }
+body { margin: 0; background: #f4f6f8; color: #1d2430; }
+header { background: #152238; color: #fff; padding: 1rem 1.5rem; }
+.layout { display: grid; grid-template-columns: 280px 1fr 320px; gap: 1rem; padding: 1rem; }
+.panel { background: #fff; border-radius: 8px; padding: 1rem; box-shadow: 0 1px 4px rgba(0,0,0,.1); }
+.reservation-list { list-style: none; padding: 0; margin: 0; display: grid; gap: .5rem; }
+.reservation-item { border: 1px solid #d9e0e8; border-radius: 6px; padding: .5rem; cursor: pointer; }
+.reservation-item.active { border-color: #0f62fe; background: #edf4ff; }
+.status { font-size: .8rem; color: #4f596b; }
+.month-nav { display: flex; justify-content: space-between; align-items: center; }
+.calendar { display: grid; grid-template-columns: repeat(7, 1fr); gap: .4rem; margin-bottom: 1rem; }
+.day-cell { border: 1px solid #d9e0e8; border-radius: 6px; min-height: 70px; padding: .3rem; cursor: pointer; }
+.day-cell.full_day { background: #ffd8d8; }
+.day-cell.partial { background: #fff2c6; }
+.day-cell.free { background: #e6f6ea; }
+.day-cell.selected { outline: 2px solid #0f62fe; }
+.hour-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: .3rem; margin-bottom: .5rem; }
+.slot-list { list-style: none; padding: 0; margin: 0; display: grid; gap: .4rem; }
+.slot-item { border: 1px solid #d9e0e8; border-radius: 6px; padding: .4rem; display: flex; justify-content: space-between; }
+.actions-row, .manual-range { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: .8rem; }
+button { cursor: pointer; border: 1px solid #bcc7d6; border-radius: 6px; padding: .4rem .6rem; background: #fff; }
+button.danger { border-color: #cc2c2c; color: #cc2c2c; }
+.muted { color: #4f596b; }
+.finance-box { display: grid; gap: .6rem; }
+.finance-row { display: flex; justify-content: space-between; }
+@media (max-width: 1200px) { .layout { grid-template-columns: 1fr; } }


### PR DESCRIPTION
### Motivation
- Añadir una pestaña de administración que permita visualizar y editar la ocupación por reserva con reglas específicas para días completos y parciales. 
- Evitar mezclar la lógica de disponibilidad operativa (buffers, bloqueos globales) dentro del editor de una reserva y mantener el modelo de datos limpio para almacenamiento.

### Description
- Se añaden tres archivos básicos en vanilla: `index.html`, `styles.css` y `app.js` que construyen una UI de 3 paneles (listado, editor calendarizado, cierre económico). 
- Implementación de datos mock que cubren los casos solicitados: una reserva parcial con múltiples slots en el mismo día, una reserva de días completos (`mode: full_day`, `slots: []`), una confirmada y una cancelada. 
- Lógica reutilizable para la gestión de ocupación: `getDayMode`, `addSlot`, `ensureFullDay`, `clearDay` y `removeSlot`, garantizando que `full_day` no guarda slots horarios y `partial` permite múltiples slots. 
- UI/UX: calendario mensual que pinta cada día como `free`/`partial`/`full_day` según `occupancy[date].mode`, selección de día, añadir slots por `checkboxes` horarios o por rango manual, listado de slots del día, eliminación de slots individuales y liberación completa del día. 
- Cierre económico en panel lateral con `depositPaid`, `finalTotal` editable, `pending` recalculado automáticamente, generación de enlace de pago mock y acción `marcar pago recibido` que deja `pending = 0` y `status = "confirmada"`.

### Testing
- Se ejecutó `node --check app.js` para validar la sintaxis de `app.js` y la comprobación fue satisfactoria. 
- Se verificó el estado del árbol de trabajo con `git status --short` para confirmar los archivos añadidos y la operación local previa al PR, y esa verificación fue satisfactoria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb443c42e883228093b31e063cae9e)