### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Modelo del repositorio
+
+Este es un **sandbox con rama-por-proyecto**. La rama `main` es solo plantilla/documentación. El código de cada proyecto vive en su propia rama (p. ej. `bebe-sueno`, `pomodoro`). **Los PRs de código deben apuntar a la rama del proyecto, nunca a `main`.**
+
+### Proyecto principal: `bebe-sueno`
+
+Stack: React 19 + Vite 6 + Tailwind CSS 4 + Cloudflare Pages Functions + D1 (SQLite).
+
+#### Comandos estándar (ver `package.json`)
+
+| Acción | Comando |
+|--------|---------|
+| Instalar deps | `npm install` |
+| Lint | `npm run lint` |
+| Build (tsc + vite) | `npm run build` |
+| Dev frontend-only | `npm run dev` |
+| Dev full-stack | Ver abajo |
+
+#### Servidor de desarrollo full-stack
+
+El script `npm run dev:cf` (`wrangler pages dev -- vite`) **no funciona** con wrangler >= 4.83 porque `pages_build_output_dir` en `wrangler.toml` y el comando proxy entran en conflicto. Workaround:
+
+1. `npm run build` (genera `dist/`)
+2. `npx wrangler pages dev dist --port 8788` (sirve estáticos + Pages Functions + D1 local)
+
+Para obtener HMR en frontend, ejecutar además `npx vite --port 5173 --host` en otra terminal y usar puerto 5173 para desarrollo visual. El puerto 8788 (wrangler) es necesario para probar llamadas a `/api/*`.
+
+#### Base de datos D1 local
+
+- Inicializar (una sola vez): `npx wrangler d1 execute sueno --local --file=./schema.sql`
+- Los datos se persisten en `.wrangler/state/v3/d1/`.
+- Si la BD ya existe, el comando anterior fallará con "table already exists". Es seguro ignorar ese error o borrar `.wrangler/state/` para resetear.
+
+#### Variables de entorno locales
+
+Copiar `.dev.vars.example` a `.dev.vars`. El valor `OTP_DEBUG_CODE=123456` permite usar `123456` como código OTP en desarrollo. Si no se define, se genera uno aleatorio visible en la cabecera `X-Debug-Otp` de la respuesta.
+
+#### Flujo de autenticación en desarrollo
+
+1. `POST /api/auth/request-otp` con `{"email":"...", "fullName":"...", "otpCase":"register"}` (primera vez) o `"otpCase":"login"`.
+2. La respuesta incluye `challengeId` y cabecera `X-Debug-Otp` con el código.
+3. `POST /api/auth/verify-otp` con `{"challengeId":"...", "code":"123456"}` → devuelve `token`.
+4. Usar `Authorization: Bearer <token>` para las demás llamadas API.
+
+#### ESLint
+
+La configuración ignora `functions/**` (backend) y solo lint-ea `src/**` (frontend React/TS).

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1706,8 +1705,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260418.1.tgz",
       "integrity": "sha512-bywXb2XmeSqrLCQYipcupLneqx015YhhNWz2v9b9iatpe8Cg551vP7ZuD5S2a6GfBka0dDnO70kIBiBvFglcrg==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -3746,7 +3744,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3820,7 +3817,6 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4098,7 +4094,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4338,7 +4333,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4969,7 +4963,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7086,7 +7079,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7096,7 +7088,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7948,7 +7939,6 @@
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "devOptional": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -8118,7 +8108,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8186,7 +8175,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -8315,7 +8303,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8706,7 +8693,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8764,7 +8750,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -8919,7 +8904,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Añade `AGENTS.md` con instrucciones específicas para agentes Cloud de Cursor que trabajen en la rama `bebe-sueno`.

### Contenido

- Modelo del repositorio (sandbox rama-por-proyecto)
- Comandos estándar (`npm install`, `lint`, `build`)
- Workaround documentado para `wrangler pages dev` >= 4.83 (conflicto `pages_build_output_dir` vs proxy command)
- Instrucciones para D1 local, `.dev.vars`, y flujo de autenticación OTP en desarrollo
- Nota sobre alcance de ESLint

### Verificación del entorno

Se verificó que todo el stack de desarrollo funciona correctamente:

| Check | Resultado |
|-------|-----------|
| `npm install` | OK (506 paquetes) |
| `npm run lint` | OK (0 errores, 3 warnings) |
| `npm run build` (tsc + vite) | OK |
| Wrangler Pages dev (D1 local) | OK en puerto 8788 |
| Registro OTP + login | OK |
| CRUD episodios sueño | OK |

### Demo

[demo_bebe_sueno_full_flow.mp4](https://cursor.com/agents/bc-d8fc382e-74ed-4131-949d-70f8e5ff6959/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_bebe_sueno_full_flow.mp4)

[Página de acceso](https://cursor.com/agents/bc-d8fc382e-74ed-4131-949d-70f8e5ff6959/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faccess_page.webp)
[Dashboard principal](https://cursor.com/agents/bc-d8fc382e-74ed-4131-949d-70f8e5ff6959/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard.webp)
[Página de timer](https://cursor.com/agents/bc-d8fc382e-74ed-4131-949d-70f8e5ff6959/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftimer_page.webp)
[Página de analytics](https://cursor.com/agents/bc-d8fc382e-74ed-4131-949d-70f8e5ff6959/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanalytics_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8fc382e-74ed-4131-949d-70f8e5ff6959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8fc382e-74ed-4131-949d-70f8e5ff6959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

