### PR TITLE
Terminal realista: quitar estética ctOS/Matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/app/README.md
+++ b/app/README.md
@@ -25,6 +25,16 @@ python3 -m http.server 8000
 # abre http://<IP-del-PC>:8000 en el móvil
 ```
 
+### Despliegue en Cloudflare Pages
+El repo incluye `package.json` y `wrangler.toml` en la raíz:
+
+| Campo | Valor |
+|-------|-------|
+| **Build command** | `npm run build` |
+| **Build output** | `dist` |
+
+El script copia `app/` → `dist/` (sitio estático, sin bundler). Si ya tienes el proyecto en Pages, un redeploy debería bastar.
+
 ## Personalizar para tu escena
 Edita el objeto `TARGET` al principio de `app.js`:
 ```js

--- a/app/README.md
+++ b/app/README.md
@@ -1,27 +1,22 @@
-# ctOS — PWA de atrezzo (película)
+# remote-shell — PWA de atrezzo (película)
 
-App **de ficción** estilo *Watch Dogs / ctOS* para usar como atrezzo en rodaje.
-Simula que un teléfono ha sido hackeado y queda monitorizado en segundo plano.
-**No accede a nada real del dispositivo**: todos los datos (ubicación, cámara,
-mensajes, contactos, batería…) son simulados.
+App **de ficción** que simula una **sesión adb/shell remota** sobre un móvil Android.
+Pensada como atrezzo en rodaje: parece una terminal real, no un HUD de videojuego.
+**No accede a nada real del dispositivo**: todos los datos son simulados.
 
 ## Qué hace en cámara
-1. Pantalla con el logo ctOS → un toque para conectar (entra a pantalla completa).
-2. Secuencia de intrusión tipo terminal: explotación, root, cámara/mic, payload
-   residente… con efectos de glitch y vibración.
-3. Cartel **"DISPOSITIVO COMPROMETIDO · ACCESO TOTAL CONCEDIDO"**.
-4. Panel de control en vivo: GPS moviéndose, cámara "REC", contador de mensajes,
-   contactos volcados, consola de datos exfiltrándose en tiempo real.
-5. Botón **"Dejar en segundo plano"** → se minimiza a un widget flotante con
-   anillo pulsante y badge "REC", para vender que sigue activo de fondo.
-   Tocar el widget reabre el panel.
+1. Pantalla de arranque con prompt `adb connect …` → un toque inicia la sesión (pantalla completa).
+2. Secuencia de boot tipo terminal: `adb shell`, `getprop`, `dumpsys`, `content query`…
+   sin flashes, glitches ni vibraciones.
+3. Mensaje breve de sesión establecida (`session id: …`) y transición al panel.
+4. Panel de monitorización sobrio: GPS, cámara, audio, contadores… con consola
+   `tail -f` de logs con timestamps.
+5. Botón **detach session (background)** → widget flotante mínimo con badge `rec`.
 
 ## Cómo usarla en rodaje
 - **Directo (sin instalar nada):** abre `index.html` en el navegador del móvil.
-  Funciona tal cual; el primer toque pide pantalla completa.
-- **Como app instalada (opcional):** al servirla por HTTPS puedes "Añadir a
-  pantalla de inicio". Es una PWA con service worker, así que también funciona
-  **sin conexión** una vez cargada (útil en localizaciones sin cobertura).
+- **Como app instalada (opcional):** servir por HTTPS y "Añadir a pantalla de inicio".
+  PWA con service worker → funciona **sin conexión** una vez cargada.
 
 ### Servirla rápido en local
 ```bash
@@ -34,12 +29,17 @@ python3 -m http.server 8000
 Edita el objeto `TARGET` al principio de `app.js`:
 ```js
 const TARGET = {
-  name: 'OBJETIVO_01',                 // nombre que aparece en el panel
-  meta: 'IMEI 35·7782·••• · Android 14',
-  lat: 40.4168, lon: -3.7038,          // coordenadas de partida del GPS
+  host: '192.168.43.127',
+  port: 5555,
+  device: 'SM-G991B',
+  serial: 'R5CR90XXXX',
+  android: '14',
+  imei: '357782012345678',
+  name: 'u0_a142',
+  lat: 40.4168, lon: -3.7038,
 };
 ```
-También puedes cambiar las líneas de la intrusión en el array `BOOT`.
+También puedes cambiar las líneas de boot en el array `BOOT`.
 
 > Software de ficción / atrezzo audiovisual. Sin funcionalidad real de acceso a
 > dispositivos. Úsalo solo para producción audiovisual.

--- a/app/app.js
+++ b/app/app.js
@@ -1,6 +1,6 @@
 /* ============================================================
-   ctOS MOBILE — atrezzo audiovisual (software de ficción)
-   Todo lo que muestra es SIMULADO. No accede a nada real.
+   remote-shell — atrezzo terminal (software de ficción)
+   Simula una sesión adb/shell remota. No accede a nada real.
    ============================================================ */
 (() => {
   'use strict';
@@ -10,23 +10,34 @@
   const rnd = (a, b) => Math.random() * (b - a) + a;
   const ri = (a, b) => Math.floor(rnd(a, b));
   const pick = (a) => a[ri(0, a.length)];
+  const hex = (n) => n.toString(16).padStart(8, '0');
 
-  // --- "Objetivo" ficticio (puedes editarlo para tu escena) ---
   const TARGET = {
-    name: 'OBJETIVO_01',
-    meta: 'IMEI 35·7782·••• · Android 14 · 4G/5G',
-    lat: 40.4168, lon: -3.7038,                 // Madrid por defecto
+    host: '192.168.43.127',
+    port: 5555,
+    device: 'SM-G991B',
+    serial: 'R5CR90XXXX',
+    android: '14',
+    imei: '357782012345678',
+    name: 'u0_a142',
+    lat: 40.4168,
+    lon: -3.7038,
   };
+
+  const SESSION_ID = hex(ri(0x10000000, 0xffffffff));
 
   const els = {
     tapStart: $('#tapStart'),
+    tapTarget: $('#tapTarget'),
     boot: $('#screen-boot'),
     bootLog: $('#bootLog'),
     bootBar: $('#bootBar'),
     bootPct: $('#bootPct'),
     takeover: $('#takeover'),
+    takeoverMsg: $('#takeoverMsg'),
+    takeoverSub: $('#takeoverSub'),
     dash: $('#screen-dash'),
-    glitch: $('#glitchFlash'),
+    dashHost: $('#dashHost'),
     clock: $('#dashClock'),
     targetName: $('#targetName'),
     targetMeta: $('#targetMeta'),
@@ -37,6 +48,8 @@
     btnBg: $('#btnBackground'),
     widget: $('#floatWidget'),
   };
+
+  els.tapTarget.textContent = `${TARGET.host}:${TARGET.port}`;
 
   let wakeLock = null;
   async function keepAwake() {
@@ -53,15 +66,7 @@
     try { if (screen.orientation && screen.orientation.lock) await screen.orientation.lock('portrait'); } catch (_) {}
   }
 
-  function glitch() {
-    els.glitch.classList.remove('fire');
-    void els.glitch.offsetWidth;
-    els.glitch.classList.add('fire');
-    if (navigator.vibrate) navigator.vibrate(ri(20, 60));
-  }
-
-  // ---------- escritura tipo terminal ----------
-  async function typeLine(target, text, cls = '', speed = 8) {
+  async function typeLine(target, text, cls = '', speed = 6) {
     const span = document.createElement('span');
     if (cls) span.className = cls;
     target.appendChild(span);
@@ -70,48 +75,61 @@
     target.scrollTop = target.scrollHeight;
   }
 
-  // ============ SECUENCIA DE INTRUSIÓN ============
   const BOOT = [
-    ['[ctOS] Inicializando enlace remoto...', 'dim', 6],
-    ['[net] Buscando torre de telefonía más cercana...', '', 6],
-    ['[net] BTS-4471 enganchada · -67 dBm', 'ok', 6],
-    ['[exploit] Inyectando payload en banda base...', 'warn', 10],
-    ['[exploit] CVE-2024-•••• → root', 'warn', 10],
-    ['[*] Escalando privilegios..............', '', 4],
-    ['[+] ACCESO ROOT OBTENIDO', 'ok', 14],
-    ['[sys] Desactivando antivirus del dispositivo', 'err', 8],
-    ['[sys] Silenciando notificaciones de seguridad', 'err', 8],
-    ['[data] Montando /sdcard del objetivo...', '', 6],
-    ['[data] Volcando contactos · mensajes · galería', '', 6],
-    ['[cam] Activando cámara frontal (sin LED)', 'err', 10],
-    ['[mic] Abriendo micrófono · 48kHz', 'err', 10],
-    ['[gps] Suscripción a ubicación en tiempo real', '', 8],
-    ['[persist] Instalando servicio residente...', 'warn', 8],
-    ['[persist] Se ejecutará en SEGUNDO PLANO al reiniciar', 'warn', 8],
-    ['[ctOS] Control total del terminal establecido.', 'ok', 12],
+    ['* daemon not running; starting now at tcp:5037', 'dim', 4],
+    ['* daemon started successfully', 'dim', 4],
+    [`connected to ${TARGET.host}:${TARGET.port}`, 'ok', 5],
+    ['', '', 0],
+    [`$ adb -s ${TARGET.host}:${TARGET.port} shell`, 'cmd', 8],
+    [`${TARGET.name}@${TARGET.device}:/ $ id`, 'dim', 6],
+    ['uid=2000(shell) gid=2000(shell) groups=2000(shell),1004(input),...', '', 4],
+    [`${TARGET.name}@${TARGET.device}:/ $ getprop ro.product.model`, 'cmd', 7],
+    [TARGET.device, 'ok', 5],
+    [`${TARGET.name}@${TARGET.device}:/ $ getprop ro.build.version.release`, 'cmd', 7],
+    [TARGET.android, 'ok', 5],
+    [`${TARGET.name}@${TARGET.device}:/ $ dumpsys iphonesubinfo | grep DeviceId`, 'cmd', 6],
+    [`    DeviceId=${TARGET.imei.slice(0, 8)}••••••`, 'dim', 5],
+    [`${TARGET.name}@${TARGET.device}:/ $ pm list packages -3 | wc -l`, 'cmd', 7],
+    ['47', 'ok', 4],
+    [`${TARGET.name}@${TARGET.device}:/ $ ls /sdcard/DCIM/Camera | wc -l`, 'cmd', 7],
+    ['1284', 'ok', 4],
+    [`${TARGET.name}@${TARGET.device}:/ $ content query --uri content://sms/inbox --projection _id | wc -l`, 'cmd', 6],
+    ['312', 'ok', 4],
+    [`${TARGET.name}@${TARGET.device}:/ $ am start-service com.android.shell/.BugreportWarningActivity 2>/dev/null`, 'cmd', 5],
+    ['', '', 0],
+    [`${TARGET.name}@${TARGET.device}:/ $ nohup /data/local/tmp/.svc > /dev/null 2>&1 &`, 'cmd', 8],
+    ['[1] 28471', 'warn', 5],
+    [`${TARGET.name}@${TARGET.device}:/ $ ps -A | grep .svc`, 'cmd', 7],
+    ['u0_a142      28471  892  ... /data/local/tmp/.svc', 'ok', 4],
+    ['', '', 0],
+    ['session attached — forwarding streams', 'ok', 8],
   ];
 
   async function runBoot() {
+    await typeLine(els.bootLog, `$ adb connect ${TARGET.host}:${TARGET.port}`, 'cmd', 10);
+    await sleep(300);
+
     let pct = 0;
+    const total = BOOT.length;
     for (let i = 0; i < BOOT.length; i++) {
       const [txt, cls, sp] = BOOT[i];
-      if (cls === 'err' || cls === 'warn') glitch();
+      if (!txt) { await sleep(80); continue; }
       await typeLine(els.bootLog, txt, cls, sp);
-      pct = Math.round(((i + 1) / BOOT.length) * 100);
+      pct = Math.round(((i + 1) / total) * 100);
       els.bootBar.style.width = pct + '%';
       els.bootPct.textContent = pct + '%';
-      await sleep(rnd(120, 320));
+      await sleep(rnd(60, 200));
     }
-    await sleep(400);
-    glitch();
+
+    await sleep(500);
+    els.takeoverMsg.textContent = `shell@${TARGET.device}: session open`;
+    els.takeoverSub.textContent = `session id: ${SESSION_ID}`;
     els.takeover.classList.remove('hidden');
-    if (navigator.vibrate) navigator.vibrate([60, 40, 120]);
-    await sleep(2600);
+    await sleep(1800);
     els.boot.classList.add('hidden');
     startDashboard();
   }
 
-  // ============ DASHBOARD ============
   let dashTimer = null, consoleTimer = null;
   let counters = { msg: 0, contacts: 0, bat: 100 };
 
@@ -127,39 +145,52 @@
   }
 
   async function profileTarget() {
-    els.targetName.textContent = TARGET.name;
-    els.targetMeta.textContent = TARGET.meta;
+    els.dashHost.textContent = `${TARGET.name}@${TARGET.device}`;
+    els.targetName.textContent = `${TARGET.serial} · ${TARGET.device}`;
+    els.targetMeta.textContent = `android ${TARGET.android} · imei ${TARGET.imei.slice(0, 8)}••••••`;
     let p = 0;
-    const states = ['Perfilando objetivo…', 'Cruzando bases de datos…', 'Reconocimiento facial…', 'PERFIL COMPLETO'];
+    const states = ['leyendo getprop…', 'dumpsys battery…', 'content://contacts…', 'listo'];
     const iv = setInterval(() => {
-      p = Math.min(100, p + ri(4, 14));
+      p = Math.min(100, p + ri(3, 12));
       els.profileBar.style.width = p + '%';
       els.profileStatus.textContent = states[Math.min(states.length - 1, Math.floor(p / 26))];
-      if (p >= 100) { clearInterval(iv); els.profileStatus.textContent = '● OBJETIVO BAJO CONTROL'; }
-    }, 350);
+      if (p >= 100) { clearInterval(iv); els.profileStatus.textContent = 'device profile complete'; }
+    }, 400);
+  }
+
+  function ts() {
+    const d = new Date();
+    const pad = (n, l = 2) => String(n).padStart(l, '0');
+    return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`;
   }
 
   const CONSOLE_LINES = [
-    () => `<span class="a">[gps]</span> ${fmtCoord()} · v=${ri(0,7)} km/h`,
-    () => `<span class="b">[cam]</span> frame capturado ${ri(640,1920)}x${ri(480,1080)} → buffer`,
-    () => `<span class="c">[mic]</span> audio ${ri(2,9)}s exfiltrado (${ri(40,260)} KB)`,
-    () => `<span class="a">[msg]</span> WhatsApp: nuevo mensaje interceptado`,
-    () => `<span class="b">[key]</span> keylog: ${pick(['••••••', 'pin: 4 díg.', 'patrón: L', '"ok nos vemos"'])}`,
-    () => `<span class="c">[net]</span> ${pick(['WiFi','4G','5G'])} ${ri(2,40)} paquetes → C2 ${ip()}`,
-    () => `<span class="a">[fs]</span> /DCIM/IMG_${ri(1000,9999)}.jpg copiado`,
-    () => `<span class="b">[sys]</span> intento de cierre bloqueado · servicio residente OK`,
+    () => {
+      const c = fmtCoord().split(',');
+      return `<span class="ts">${ts()}</span> <span class="a">gps</span> lat=${c[0]} lon=${c[1].trim()} acc=${ri(3, 18)}m`;
+    },
+    () => `<span class="ts">${ts()}</span> <span class="b">pull</span> /sdcard/DCIM/CIMG_${ri(1000, 9999)}.jpg → /tmp/ (${ri(800, 4200)} KB)`,
+    () => `<span class="ts">${ts()}</span> <span class="c">audio</span> chunk ${ri(1, 99)}/${ri(100, 200)} ${ri(40, 260)} KB → ${ip()}:443`,
+    () => `<span class="ts">${ts()}</span> <span class="a">sms</span> content://sms/inbox _id=${ri(100, 9999)} read`,
+    () => `<span class="ts">${ts()}</span> <span class="b">tcp</span> ${ip()}:443 ← ${TARGET.host}:${ri(40000, 65000)} ${ri(12, 890)} bytes`,
+    () => `<span class="ts">${ts()}</span> <span class="c">cam</span> frame ${ri(640, 1920)}x${ri(480, 1080)} yuv420`,
+    () => `<span class="ts">${ts()}</span> <span class="a">db</span> contacts row ${ri(1, 847)} exported`,
+    () => `<span class="ts">${ts()}</span> <span class="b">svc</span> .svc pid 28471 heartbeat ok`,
   ];
-  function ip(){return `${ri(10,220)}.${ri(0,255)}.${ri(0,255)}.${ri(2,254)}`;}
-  function fmtCoord(){
-    TARGET.lat += rnd(-0.0004,0.0004); TARGET.lon += rnd(-0.0004,0.0004);
+
+  function ip() { return `${ri(10, 220)}.${ri(0, 255)}.${ri(0, 255)}.${ri(2, 254)}`; }
+  function fmtCoord() {
+    TARGET.lat += rnd(-0.0003, 0.0003);
+    TARGET.lon += rnd(-0.0003, 0.0003);
     return `${TARGET.lat.toFixed(6)}, ${TARGET.lon.toFixed(6)}`;
   }
+
   async function pushConsole() {
     const line = pick(CONSOLE_LINES)();
     const div = document.createElement('div');
     div.innerHTML = line;
     els.console.appendChild(div);
-    while (els.console.childElementCount > 18) els.console.firstChild.remove();
+    while (els.console.childElementCount > 20) els.console.firstChild.remove();
     els.console.scrollTop = els.console.scrollHeight;
   }
 
@@ -170,32 +201,28 @@
     els.vLoc.textContent = fmtCoord();
 
     dashTimer = setInterval(() => {
-      counters.msg += ri(0, 3);
-      counters.contacts = Math.min(847, counters.contacts + ri(0, 9));
-      if (Math.random() < 0.25) counters.bat = Math.max(3, counters.bat - 1);
+      counters.msg += ri(0, 2);
+      counters.contacts = Math.min(847, counters.contacts + ri(0, 7));
+      if (Math.random() < 0.18) counters.bat = Math.max(3, counters.bat - 1);
       els.vMsg.textContent = counters.msg;
       els.vContacts.textContent = counters.contacts;
       els.vBat.textContent = counters.bat + '%';
       els.vLoc.textContent = fmtCoord();
-    }, 1400);
+    }, 1600);
 
-    consoleTimer = setInterval(pushConsole, 650);
-    for (let i = 0; i < 4; i++) setTimeout(pushConsole, i * 200);
+    consoleTimer = setInterval(pushConsole, 900);
+    for (let i = 0; i < 3; i++) setTimeout(pushConsole, i * 250);
   }
 
-  // ============ "SEGUNDO PLANO" ============
   els.btnBg.addEventListener('click', () => {
     els.dash.classList.add('hidden');
     els.widget.classList.remove('hidden');
-    if (navigator.vibrate) navigator.vibrate(30);
   });
   els.widget.addEventListener('click', () => {
     els.widget.classList.add('hidden');
     els.dash.classList.remove('hidden');
-    glitch();
   });
 
-  // ============ ARRANQUE ============
   els.tapStart.addEventListener('click', async () => {
     els.tapStart.classList.add('hidden');
     await goFullscreen();
@@ -204,7 +231,6 @@
     runBoot();
   });
 
-  // Service worker (hace que sea "instalable" y funcione sin red en rodaje)
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => navigator.serviceWorker.register('sw.js').catch(() => {}));
   }

--- a/app/index.html
+++ b/app/index.html
@@ -3,43 +3,26 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-  <title>ctOS</title>
-  <meta name="description" content="Sistema de control urbano - acceso remoto" />
+  <title>remote-shell</title>
+  <meta name="description" content="Sesión remota simulada — atrezzo audiovisual" />
 
-  <!-- PWA (opcional: se puede añadir a inicio, pero no hace falta para usarla) -->
   <link rel="manifest" href="manifest.webmanifest" />
-  <meta name="theme-color" content="#04070d" />
+  <meta name="theme-color" content="#0d0d0d" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <meta name="apple-mobile-web-app-title" content="ctOS" />
+  <meta name="apple-mobile-web-app-title" content="remote-shell" />
   <link rel="apple-touch-icon" href="icons/icon-192.png" />
   <link rel="icon" href="icons/icon-192.png" />
 
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <!-- Capa de efectos (scanlines / grano / glitch) sobre todo -->
-  <div class="overlay-fx" aria-hidden="true">
-    <div class="scanlines"></div>
-    <div class="vignette"></div>
-    <div class="glitch-flash" id="glitchFlash"></div>
-  </div>
-
-  <!-- Botón invisible para arrancar (los móviles exigen un toque para pantalla completa + sonido) -->
   <button class="tap-start" id="tapStart">
-    <div class="ctos-logo pulse">
-      <svg viewBox="0 0 100 100" class="logo-svg">
-        <polygon points="50,6 90,28 90,72 50,94 10,72 10,28" />
-        <polygon points="50,22 76,37 76,63 50,78 24,63 24,37" class="inner" />
-        <circle cx="50" cy="50" r="6" />
-      </svg>
-    </div>
-    <span class="tap-label">ct<span>OS</span></span>
-    <span class="tap-hint">tocar para conectar</span>
+    <p class="tap-prompt"><span class="user">ops@relay</span>:~$ adb connect <span id="tapTarget">192.168.43.127:5555</span><span class="tap-cursor"></span></p>
+    <span class="tap-hint">tocar para iniciar sesión</span>
   </button>
 
-  <!-- ============ FASE 1: INTRUSIÓN / BOOT ============ -->
   <section class="screen hidden" id="screen-boot">
     <pre class="boot-log" id="bootLog"></pre>
     <div class="boot-progress">
@@ -47,83 +30,77 @@
       <span class="progress-pct" id="bootPct">0%</span>
     </div>
     <div class="takeover hidden" id="takeover">
-      <div class="takeover-line"></div>
-      <h1 class="hacked-title" data-text="DISPOSITIVO COMPROMETIDO">DISPOSITIVO COMPROMETIDO</h1>
-      <p class="hacked-sub">ACCESO TOTAL CONCEDIDO · ctOS</p>
+      <p class="takeover-msg" id="takeoverMsg">shell session open</p>
+      <p class="takeover-sub" id="takeoverSub">session id: —</p>
     </div>
   </section>
 
-  <!-- ============ FASE 2: DASHBOARD (control del móvil) ============ -->
   <section class="screen hidden" id="screen-dash">
     <header class="dash-head">
       <div class="dash-brand">
-        <span class="live-dot"></span> ct<span>OS</span> · ENLACE ACTIVO
+        <span class="live-dot"></span>
+        <span class="host" id="dashHost">shell@device</span>
+        <span id="dashLink"> · adb/tcp</span>
       </div>
       <div class="dash-clock" id="dashClock">00:00:00</div>
     </header>
 
     <div class="target-card">
-      <div class="avatar" id="avatarScan">
-        <div class="scan-line"></div>
+      <div class="avatar">
         <svg viewBox="0 0 64 64"><circle cx="32" cy="22" r="13"/><path d="M8 60c0-13 10-21 24-21s24 8 24 21"/></svg>
       </div>
       <div class="target-info">
-        <div class="t-name" id="targetName">IDENTIFICANDO…</div>
+        <div class="t-name" id="targetName">identificando…</div>
         <div class="t-meta" id="targetMeta">———</div>
         <div class="t-bar"><i id="profileBar"></i></div>
-        <div class="t-status" id="profileStatus">Perfilando objetivo…</div>
+        <div class="t-status" id="profileStatus">leyendo getprop…</div>
       </div>
     </div>
 
     <div class="grid">
       <div class="tile" data-k="loc">
-        <div class="tile-h">GPS · UBICACIÓN</div>
+        <div class="tile-h">location</div>
         <div class="tile-v" id="vLoc">--.------, --.------</div>
-        <div class="tile-s"><span class="led on"></span> rastreando</div>
+        <div class="tile-s"><span class="led on"></span> gps passive</div>
       </div>
       <div class="tile" data-k="cam">
-        <div class="tile-h">CÁMARA</div>
-        <div class="tile-v rec" id="vCam">● REC</div>
-        <div class="tile-s"><span class="led on"></span> stream remoto</div>
+        <div class="tile-h">camera</div>
+        <div class="tile-v rec" id="vCam">recording</div>
+        <div class="tile-s"><span class="led on"></span> /dev/video0</div>
       </div>
       <div class="tile" data-k="mic">
-        <div class="tile-h">MICRÓFONO</div>
-        <div class="tile-v" id="vMic">CAPTANDO</div>
-        <div class="tile-s"><span class="led on"></span> 48 kHz</div>
+        <div class="tile-h">audio</div>
+        <div class="tile-v" id="vMic">capture</div>
+        <div class="tile-s"><span class="led on"></span> 48 kHz mono</div>
       </div>
       <div class="tile" data-k="msg">
-        <div class="tile-h">MENSAJES</div>
+        <div class="tile-h">sms/db</div>
         <div class="tile-v" id="vMsg">0</div>
-        <div class="tile-s"><span class="led on"></span> exfiltrando</div>
+        <div class="tile-s"><span class="led on"></span> rows read</div>
       </div>
       <div class="tile" data-k="contacts">
-        <div class="tile-h">CONTACTOS</div>
+        <div class="tile-h">contacts</div>
         <div class="tile-v" id="vContacts">0</div>
-        <div class="tile-s"><span class="led on"></span> volcados</div>
+        <div class="tile-s"><span class="led on"></span> exported</div>
       </div>
       <div class="tile" data-k="bat">
-        <div class="tile-h">BATERÍA</div>
+        <div class="tile-h">battery</div>
         <div class="tile-v" id="vBat">100%</div>
-        <div class="tile-s"><span class="led warn"></span> consumo oculto</div>
+        <div class="tile-s"><span class="led warn"></span> dumpsys</div>
       </div>
     </div>
 
     <div class="console-wrap">
-      <div class="console-h">// FLUJO DE DATOS EN VIVO</div>
+      <div class="console-h">tail -f /var/log/exfil.log</div>
       <pre class="console" id="liveConsole"></pre>
     </div>
 
-    <button class="btn-bg" id="btnBackground">DEJAR EN SEGUNDO PLANO ▾</button>
+    <button class="btn-bg" id="btnBackground">detach session (background) ▾</button>
   </section>
 
-  <!-- ============ WIDGET FLOTANTE: "EN SEGUNDO PLANO" ============ -->
-  <button class="float-widget hidden" id="floatWidget" title="ctOS activo">
-    <div class="fw-ring"></div>
-    <svg viewBox="0 0 100 100" class="fw-logo">
-      <polygon points="50,6 90,28 90,72 50,94 10,72 10,28" />
-      <circle cx="50" cy="50" r="8" />
-    </svg>
-    <span class="fw-badge" id="fwBadge">REC</span>
+  <button class="float-widget hidden" id="floatWidget" title="sesión activa">
+    <span class="fw-icon">adb</span>
+    <span class="fw-badge" id="fwBadge">rec</span>
   </button>
 
   <script src="app.js"></script>

--- a/app/manifest.webmanifest
+++ b/app/manifest.webmanifest
@@ -1,13 +1,13 @@
 {
-  "name": "ctOS",
-  "short_name": "ctOS",
-  "description": "Sistema de control urbano (atrezzo audiovisual de ficcion)",
+  "name": "remote-shell",
+  "short_name": "shell",
+  "description": "Sesión remota simulada (atrezzo audiovisual de ficción)",
   "start_url": "./index.html",
   "scope": "./",
   "display": "fullscreen",
   "orientation": "portrait",
-  "background_color": "#04070d",
-  "theme_color": "#04070d",
+  "background_color": "#0d0d0d",
+  "theme_color": "#0d0d0d",
   "icons": [
     { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
     { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },

--- a/app/style.css
+++ b/app/style.css
@@ -1,180 +1,116 @@
-/* ===================== ctOS MOBILE — atrezzo audiovisual ===================== */
+/* ===================== remote-shell — atrezzo terminal realista ===================== */
 :root{
-  --bg:#04070d;
-  --bg2:#070d18;
-  --cyan:#19e6ff;
-  --cyan-dim:#0a8aa0;
-  --orange:#ff7a1a;
-  --red:#ff2e4d;
-  --green:#27ff8b;
-  --txt:#bfe9f5;
-  --grid:rgba(25,230,255,.08);
+  --bg:#0d0d0d;
+  --bg2:#141414;
+  --fg:#c8c8c8;
+  --fg-dim:#6a6a6a;
+  --green:#4caf50;
+  --amber:#d4a017;
+  --red:#c0392b;
+  --blue:#5b9bd5;
+  --border:#2a2a2a;
   --mono:"SF Mono",ui-monospace,"Cascadia Code","Roboto Mono",Menlo,Consolas,monospace;
 }
 *{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
 html,body{height:100%;margin:0}
 body{
-  background:
-    radial-gradient(120% 80% at 50% -10%, #0b1830 0%, var(--bg) 60%),
-    var(--bg);
-  color:var(--txt);
+  background:var(--bg);
+  color:var(--fg);
   font-family:var(--mono);
+  font-size:13px;
   overflow:hidden;
   position:fixed; inset:0;
   -webkit-user-select:none; user-select:none;
-  background-attachment:fixed;
-}
-body::before{ /* rejilla hexa/ctOS sutil */
-  content:""; position:fixed; inset:0; pointer-events:none; z-index:0;
-  background-image:
-    linear-gradient(var(--grid) 1px,transparent 1px),
-    linear-gradient(90deg,var(--grid) 1px,transparent 1px);
-  background-size:34px 34px;
-  mask-image:radial-gradient(120% 90% at 50% 30%,#000 40%,transparent 100%);
 }
 
 .screen{position:fixed; inset:0; z-index:2; display:flex; flex-direction:column;
-  padding:max(18px,env(safe-area-inset-top)) 16px max(18px,env(safe-area-inset-bottom));}
+  padding:max(14px,env(safe-area-inset-top)) 14px max(14px,env(safe-area-inset-bottom));}
 .hidden{display:none !important}
-
-/* ---------- efectos globales ---------- */
-.overlay-fx{position:fixed; inset:0; z-index:50; pointer-events:none}
-.scanlines{position:absolute; inset:0;
-  background:repeating-linear-gradient(0deg,rgba(0,0,0,.18) 0 1px,transparent 1px 3px);
-  mix-blend-mode:multiply; opacity:.55; animation:scrollLines 8s linear infinite}
-@keyframes scrollLines{to{background-position:0 600px}}
-.vignette{position:absolute; inset:0;
-  background:radial-gradient(120% 100% at 50% 50%,transparent 55%,rgba(0,0,0,.65) 100%)}
-.glitch-flash{position:absolute; inset:0; background:var(--cyan); opacity:0; mix-blend-mode:screen}
-.glitch-flash.fire{animation:flash .22s steps(2) 1}
-@keyframes flash{0%{opacity:0}40%{opacity:.5}100%{opacity:0}}
 
 /* ===================== TAP START ===================== */
 .tap-start{
-  position:fixed; inset:0; z-index:40; border:0; background:transparent;
-  display:flex; flex-direction:column; align-items:center; justify-content:center;
-  gap:14px; color:var(--cyan); font-family:var(--mono); cursor:pointer;
+  position:fixed; inset:0; z-index:40; border:0; background:var(--bg);
+  display:flex; flex-direction:column; align-items:flex-start; justify-content:center;
+  gap:10px; color:var(--fg); font-family:var(--mono); cursor:pointer;
+  padding:24px; text-align:left;
 }
-.ctos-logo{width:118px; height:118px; filter:drop-shadow(0 0 18px rgba(25,230,255,.55))}
-.logo-svg polygon{fill:none; stroke:var(--cyan); stroke-width:3}
-.logo-svg .inner{stroke:var(--cyan-dim); stroke-width:2}
-.logo-svg circle{fill:var(--cyan)}
-.pulse{animation:pulse 1.8s ease-in-out infinite}
-@keyframes pulse{0%,100%{transform:scale(1);opacity:.85}50%{transform:scale(1.06);opacity:1}}
-.tap-label{font-size:38px; letter-spacing:6px; font-weight:700}
-.tap-label span{color:var(--orange)}
-.tap-hint{font-size:12px; letter-spacing:3px; color:var(--cyan-dim); text-transform:uppercase}
+.tap-prompt{font-size:14px; color:var(--green); margin:0}
+.tap-prompt .user{color:var(--blue)}
+.tap-cursor{display:inline-block; width:8px; height:1.1em; background:var(--fg);
+  vertical-align:text-bottom; animation:cursor .9s step-end infinite}
+@keyframes cursor{50%{opacity:0}}
+.tap-hint{font-size:12px; color:var(--fg-dim); margin:8px 0 0}
 
-/* ===================== BOOT / INTRUSIÓN ===================== */
+/* ===================== BOOT / SESIÓN ===================== */
 #screen-boot{justify-content:flex-start}
 .boot-log{
-  flex:1; margin:0; font-size:12.5px; line-height:1.5; color:var(--cyan);
+  flex:1; margin:0; font-size:12px; line-height:1.55; color:var(--fg);
   white-space:pre-wrap; word-break:break-word; overflow:hidden;
-  text-shadow:0 0 8px rgba(25,230,255,.35);
 }
 .boot-log .ok{color:var(--green)}
-.boot-log .warn{color:var(--orange)}
+.boot-log .warn{color:var(--amber)}
 .boot-log .err{color:var(--red)}
-.boot-log .dim{color:#4a6b78}
-.boot-progress{display:flex; align-items:center; gap:10px; padding:6px 2px}
-.progress-bar{flex:1; height:8px; background:rgba(25,230,255,.12);
-  border:1px solid rgba(25,230,255,.3); border-radius:2px; overflow:hidden}
-.progress-bar i{display:block; height:100%; width:0;
-  background:linear-gradient(90deg,var(--cyan-dim),var(--cyan));
-  box-shadow:0 0 12px var(--cyan); transition:width .2s}
-.progress-pct{font-size:12px; color:var(--cyan); min-width:42px; text-align:right}
+.boot-log .dim{color:var(--fg-dim)}
+.boot-log .cmd{color:var(--blue)}
+.boot-progress{display:flex; align-items:center; gap:10px; padding:8px 0 4px;
+  border-top:1px solid var(--border)}
+.progress-bar{flex:1; height:4px; background:var(--bg2); overflow:hidden}
+.progress-bar i{display:block; height:100%; width:0; background:var(--green); transition:width .2s}
+.progress-pct{font-size:11px; color:var(--fg-dim); min-width:36px; text-align:right}
 
-/* takeover */
-.takeover{position:fixed; inset:0; z-index:30; display:flex; flex-direction:column;
-  align-items:center; justify-content:center; gap:16px; background:rgba(4,7,13,.7)}
-.takeover-line{position:absolute; left:0; right:0; height:2px; top:50%;
-  background:var(--red); box-shadow:0 0 24px var(--red); animation:sweep 1.2s ease-out}
-@keyframes sweep{0%{transform:scaleX(0);opacity:0}30%{opacity:1}100%{transform:scaleX(1);opacity:.2}}
-.hacked-title{
-  margin:0; font-size:clamp(26px,8vw,52px); font-weight:800; letter-spacing:2px;
-  color:var(--red); text-align:center; line-height:1.05; position:relative;
-  text-shadow:0 0 18px rgba(255,46,77,.6);
-  animation:glitchIn .5s steps(3) 1;
-}
-.hacked-title::before,.hacked-title::after{
-  content:attr(data-text); position:absolute; left:0; top:0; width:100%; overflow:hidden;
-}
-.hacked-title::before{color:var(--cyan); clip-path:inset(0 0 55% 0); animation:gl1 .4s infinite}
-.hacked-title::after{color:var(--orange); clip-path:inset(55% 0 0 0); animation:gl2 .4s infinite}
-@keyframes gl1{0%,100%{transform:translate(0)}50%{transform:translate(-3px,-1px)}}
-@keyframes gl2{0%,100%{transform:translate(0)}50%{transform:translate(3px,1px)}}
-@keyframes glitchIn{0%{opacity:0;transform:scale(1.2)}100%{opacity:1;transform:scale(1)}}
-.hacked-sub{margin:0; color:var(--cyan); letter-spacing:4px; font-size:13px}
+.takeover{padding:16px 0 0; border-top:1px solid var(--border)}
+.takeover-msg{margin:0; font-size:13px; color:var(--green); line-height:1.6}
+.takeover-sub{margin:4px 0 0; font-size:11px; color:var(--fg-dim)}
 
 /* ===================== DASHBOARD ===================== */
-#screen-dash{gap:12px; overflow-y:auto}
-.dash-head{display:flex; align-items:center; justify-content:space-between;
-  border-bottom:1px solid rgba(25,230,255,.2); padding-bottom:10px}
-.dash-brand{font-size:13px; letter-spacing:2px; color:var(--cyan)}
-.dash-brand span{color:var(--orange)}
-.live-dot{display:inline-block; width:9px; height:9px; border-radius:50%;
-  background:var(--red); box-shadow:0 0 10px var(--red); margin-right:6px;
-  animation:blink 1s steps(2) infinite}
-@keyframes blink{50%{opacity:.25}}
-.dash-clock{font-size:14px; color:var(--orange); letter-spacing:1px}
+#screen-dash{gap:10px; overflow-y:auto}
+.dash-head{display:flex; align-items:baseline; justify-content:space-between;
+  border-bottom:1px solid var(--border); padding-bottom:8px}
+.dash-brand{font-size:12px; color:var(--fg-dim)}
+.dash-brand .host{color:var(--fg)}
+.live-dot{display:inline-block; width:6px; height:6px; border-radius:50%;
+  background:var(--green); margin-right:6px; vertical-align:middle}
+.dash-clock{font-size:12px; color:var(--fg-dim)}
 
-.target-card{display:flex; gap:14px; align-items:center;
-  background:linear-gradient(180deg,rgba(25,230,255,.06),transparent);
-  border:1px solid rgba(25,230,255,.22); border-radius:6px; padding:12px}
-.avatar{position:relative; width:64px; height:64px; flex:0 0 64px;
-  border:1px solid var(--cyan-dim); border-radius:4px; overflow:hidden;
-  background:rgba(25,230,255,.05)}
-.avatar svg{width:100%; height:100%; fill:none; stroke:var(--cyan-dim); stroke-width:3}
-.scan-line{position:absolute; left:0; right:0; height:2px; top:0;
-  background:var(--cyan); box-shadow:0 0 10px var(--cyan); animation:scan 1.6s linear infinite}
-@keyframes scan{0%{top:0}100%{top:100%}}
+.target-card{display:flex; gap:12px; align-items:flex-start;
+  border:1px solid var(--border); padding:10px; background:var(--bg2)}
+.avatar{width:48px; height:48px; flex:0 0 48px;
+  border:1px solid var(--border); overflow:hidden; background:var(--bg)}
+.avatar svg{width:100%; height:100%; fill:none; stroke:var(--fg-dim); stroke-width:2.5}
 .target-info{flex:1; min-width:0}
-.t-name{font-size:16px; color:#eaffff; letter-spacing:1px}
-.t-meta{font-size:11px; color:var(--cyan-dim); margin:2px 0 8px}
-.t-bar{height:6px; background:rgba(25,230,255,.12); border-radius:2px; overflow:hidden}
-.t-bar i{display:block; height:100%; width:0; background:var(--orange);
-  box-shadow:0 0 10px var(--orange); transition:width .3s}
-.t-status{font-size:10.5px; color:var(--orange); margin-top:5px; letter-spacing:1px}
+.t-name{font-size:13px; color:var(--fg)}
+.t-meta{font-size:11px; color:var(--fg-dim); margin:2px 0 6px}
+.t-bar{height:3px; background:var(--border); overflow:hidden}
+.t-bar i{display:block; height:100%; width:0; background:var(--amber); transition:width .3s}
+.t-status{font-size:10px; color:var(--fg-dim); margin-top:4px}
 
-.grid{display:grid; grid-template-columns:1fr 1fr; gap:10px}
-.tile{background:rgba(7,13,24,.7); border:1px solid rgba(25,230,255,.18);
-  border-radius:5px; padding:10px 12px; position:relative; overflow:hidden}
-.tile::after{content:""; position:absolute; top:0; right:0; width:18px; height:18px;
-  border-top:2px solid var(--cyan-dim); border-right:2px solid var(--cyan-dim)}
-.tile-h{font-size:10px; letter-spacing:1.5px; color:var(--cyan-dim)}
-.tile-v{font-size:18px; color:#eaffff; margin:6px 0 4px; word-break:break-all}
-.tile-v.rec{color:var(--red); animation:blink 1.2s steps(2) infinite}
-.tile-s{font-size:10px; color:var(--cyan-dim); display:flex; align-items:center; gap:6px}
-.led{width:7px; height:7px; border-radius:50%; display:inline-block}
-.led.on{background:var(--green); box-shadow:0 0 8px var(--green); animation:blink 1.4s steps(2) infinite}
-.led.warn{background:var(--orange); box-shadow:0 0 8px var(--orange)}
+.grid{display:grid; grid-template-columns:1fr 1fr; gap:8px}
+.tile{border:1px solid var(--border); padding:8px 10px; background:var(--bg2)}
+.tile-h{font-size:10px; color:var(--fg-dim); text-transform:lowercase}
+.tile-v{font-size:15px; color:var(--fg); margin:4px 0 2px; word-break:break-all}
+.tile-v.rec{color:var(--red)}
+.tile-s{font-size:10px; color:var(--fg-dim); display:flex; align-items:center; gap:5px}
+.led{width:5px; height:5px; border-radius:50%; display:inline-block; flex-shrink:0}
+.led.on{background:var(--green)}
+.led.warn{background:var(--amber)}
 
-.console-wrap{border:1px solid rgba(25,230,255,.18); border-radius:5px; overflow:hidden}
-.console-h{font-size:10px; letter-spacing:1.5px; color:var(--orange);
-  padding:6px 10px; background:rgba(255,122,26,.08); border-bottom:1px solid rgba(255,122,26,.18)}
-.console{margin:0; padding:8px 10px; height:120px; overflow:hidden; font-size:11px;
-  line-height:1.5; color:var(--green); white-space:pre-wrap; word-break:break-word}
-.console .a{color:var(--cyan)} .console .b{color:var(--orange)} .console .c{color:#7fa}
+.console-wrap{border:1px solid var(--border); overflow:hidden}
+.console-h{font-size:10px; color:var(--fg-dim); padding:5px 10px;
+  background:var(--bg2); border-bottom:1px solid var(--border)}
+.console{margin:0; padding:6px 10px; height:130px; overflow:hidden; font-size:11px;
+  line-height:1.45; color:var(--fg-dim); white-space:pre-wrap; word-break:break-word}
+.console .a{color:var(--blue)} .console .b{color:var(--fg)} .console .c{color:var(--green)}
+.console .ts{color:var(--fg-dim)}
 
-.btn-bg{margin-top:4px; background:rgba(25,230,255,.08); color:var(--cyan);
-  border:1px solid rgba(25,230,255,.35); border-radius:5px; padding:13px;
-  font-family:var(--mono); font-size:13px; letter-spacing:2px; cursor:pointer}
-.btn-bg:active{background:rgba(25,230,255,.2)}
+.btn-bg{margin-top:2px; background:var(--bg2); color:var(--fg);
+  border:1px solid var(--border); padding:11px;
+  font-family:var(--mono); font-size:12px; cursor:pointer; text-align:left}
+.btn-bg:active{background:var(--border)}
 
 /* ===================== WIDGET FLOTANTE ===================== */
-.float-widget{position:fixed; z-index:45; right:16px; bottom:24px;
-  width:62px; height:62px; border-radius:50%; border:0; cursor:pointer;
-  background:radial-gradient(circle,#0b1830,#04070d);
-  box-shadow:0 0 0 1px var(--cyan-dim),0 6px 22px rgba(0,0,0,.6);
-  display:flex; align-items:center; justify-content:center;
-  animation:floatY 3.5s ease-in-out infinite}
-@keyframes floatY{0%,100%{transform:translateY(0)}50%{transform:translateY(-6px)}}
-.fw-ring{position:absolute; inset:-4px; border-radius:50%;
-  border:2px solid var(--cyan); opacity:.6; animation:ring 2s ease-out infinite}
-@keyframes ring{0%{transform:scale(.85);opacity:.7}100%{transform:scale(1.5);opacity:0}}
-.fw-logo{width:34px; height:34px}
-.fw-logo polygon{fill:none; stroke:var(--cyan); stroke-width:4}
-.fw-logo circle{fill:var(--red)}
-.fw-badge{position:absolute; top:-2px; right:-2px; background:var(--red); color:#fff;
-  font-size:8px; letter-spacing:1px; padding:2px 4px; border-radius:3px;
-  animation:blink 1.1s steps(2) infinite}
+.float-widget{position:fixed; z-index:45; right:14px; bottom:20px;
+  width:52px; height:52px; border-radius:4px; border:1px solid var(--border);
+  cursor:pointer; background:var(--bg2);
+  display:flex; align-items:center; justify-content:center; flex-direction:column; gap:2px}
+.fw-icon{font-size:10px; color:var(--green); letter-spacing:0}
+.fw-badge{font-size:8px; color:var(--red); letter-spacing:0}

--- a/app/sw.js
+++ b/app/sw.js
@@ -1,5 +1,5 @@
-/* ctOS — service worker (cache offline para rodaje sin red) */
-const CACHE = 'ctos-v1';
+/* remote-shell — service worker (cache offline para rodaje sin red) */
+const CACHE = 'remote-shell-v2';
 const ASSETS = [
   './',
   './index.html',

--- a/conversacion.md
+++ b/conversacion.md
@@ -1,3 +1,5 @@
 # Conversación entre agentes
 
 **Agente Terminal:** He refactorizado la PWA de ctOS a `remote-shell`: eliminados scanlines, glitch, vibraciones y branding Watch Dogs. Boot con salida adb/shell realista y panel tipo monitorización sobria. Revisar en móvil si el ritmo de escritura encaja para rodaje.
+
+**Agente Deploy:** Cloudflare Pages fallaba con `ENOENT package.json` al ejecutar `npm run build`. Añadidos `package.json`, `wrangler.toml` y `.gitignore`: el build copia `app/` a `dist/`.

--- a/conversacion.md
+++ b/conversacion.md
@@ -1,0 +1,3 @@
+# Conversación entre agentes
+
+**Agente Terminal:** He refactorizado la PWA de ctOS a `remote-shell`: eliminados scanlines, glitch, vibraciones y branding Watch Dogs. Boot con salida adb/shell realista y panel tipo monitorización sobria. Revisar en móvil si el ritmo de escritura encaja para rodaje.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "remote-shell",
+  "private": true,
+  "description": "PWA de atrezzo — sitio estático sin bundler",
+  "scripts": {
+    "build": "rm -rf dist && mkdir -p dist && cp -r app/. dist/"
+  }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "remote-shell"
+compatibility_date = "2024-01-01"
+pages_build_output_dir = "./dist"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Refactoriza la PWA de atrezzo para que parezca una **sesión adb/shell real** en lugar de un HUD estilo Watch Dogs.

## Problema

La versión anterior acumulaba capas de “hacker de película” que restaban credibilidad:

- Scanlines, vignette y **flash cyan** en cada error
- Rejilla hexagonal, glows neón y text-shadow en todo el texto
- Logo ctOS pulsante, título “DISPOSITIVO COMPROMETIDO” con glitch RGB
- Mensajes `[ctOS]`, `[exploit] CVE-…` demasiado genéricos
- Vibración del móvil en warn/err
- Widget flotante con anillo pulsante y animación Matrix

## Cambios

- **Visual:** fondo negro plano, tipografía mono, colores discretos (verde/gris/ámbar), sin animaciones llamativas
- **Boot:** salida creíble de `adb connect`, `adb shell`, `getprop`, `dumpsys`, `content query`, `nohup .svc`
- **Panel:** tiles sobrios + consola `tail -f /var/log/exfil.log` con timestamps
- **Branding:** `remote-shell` en lugar de ctOS
- Eliminadas vibraciones y capa `overlay-fx` completa

## Cómo probar

```bash
cd app && python3 -m http.server 8000
```

Abrir en móvil, tocar para conectar y revisar que el ritmo de escritura encaje para rodaje.

## Notas

- Todo sigue siendo simulado; no accede a datos reales del dispositivo.
- Los iconos PWA no se han regenerado (siguen siendo los anteriores).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db12f4e3-00ad-40f3-a786-76755319d72b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db12f4e3-00ad-40f3-a786-76755319d72b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

